### PR TITLE
Remove double add of mixinType

### DIFF
--- a/src/Bannerlord.UIExtenderEx/Components/ViewModelComponent.cs
+++ b/src/Bannerlord.UIExtenderEx/Components/ViewModelComponent.cs
@@ -83,7 +83,6 @@ namespace Bannerlord.UIExtenderEx.Components
                 Utils.Fail($"Failed to find base type for mixin {mixinType}, should be specialized as T of ViewModelMixin<T>!");
                 return;
             }
-            Mixins.GetOrAdd(viewModelType, _ => new List<Type>()).Add(mixinType);
 
             if (handleDerived)
             {


### PR DESCRIPTION
mixinType was added twice to Mixins. First in the deleted line and then via Patch call.
This caused OnRefresh to be called twice and seems like it's overall bad time.