### PR TITLE
Update for Bannerlord 1.3.15 & Harmony 2.4.2.225

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,40 @@
+set dotenv-load := true
+
+platform := if os_family() == "windows" { "windows" } else { "unix" }
+platform_justfile := justfile_directory() + "/Justfile." + platform
+
+# List recipes for the current platform.
+default:
+    @just --justfile "{{ platform_justfile }}" --working-directory "{{ justfile_directory() }}" --list
+
+# Check required local tools and Bannerlord path configuration.
+doctor:
+    @just --justfile "{{ platform_justfile }}" --working-directory "{{ justfile_directory() }}" doctor
+
+# Build the solution. Defaults to Stable_Debug.
+build configuration="Stable_Debug":
+    @just --justfile "{{ platform_justfile }}" --working-directory "{{ justfile_directory() }}" build "{{ configuration }}"
+
+# Build all supported configurations.
+build-all:
+    @just --justfile "{{ platform_justfile }}" --working-directory "{{ justfile_directory() }}" build-all
+
+# Run the NUnit test project. Defaults to Stable_Debug.
+test configuration="Stable_Debug":
+    @just --justfile "{{ platform_justfile }}" --working-directory "{{ justfile_directory() }}" test "{{ configuration }}"
+
+# Run tests for all supported configurations.
+test-all:
+    @just --justfile "{{ platform_justfile }}" --working-directory "{{ justfile_directory() }}" test-all
+
+# Build a local module zip and NuGet packages. Defaults to Stable_Release.
+package configuration="Stable_Release":
+    @just --justfile "{{ platform_justfile }}" --working-directory "{{ justfile_directory() }}" package "{{ configuration }}"
+
+# Build, test, then package using platform-specific recipes.
+all:
+    @just --justfile "{{ platform_justfile }}" --working-directory "{{ justfile_directory() }}" all
+
+# Remove local artifacts and clean the solution. Defaults to Stable_Debug.
+clean configuration="Stable_Debug":
+    @just --justfile "{{ platform_justfile }}" --working-directory "{{ justfile_directory() }}" clean "{{ configuration }}"

--- a/Justfile.unix
+++ b/Justfile.unix
@@ -1,0 +1,65 @@
+set dotenv-load := true
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+root := justfile_directory()
+dotnet := env_var_or_default("DOTNET", "dotnet")
+platform := env_var_or_default("PLATFORM", "x64")
+solution := root + "/src/Bannerlord.UIExtenderEx.sln"
+project := root + "/src/Bannerlord.UIExtenderEx/Bannerlord.UIExtenderEx.csproj"
+test_project := root + "/tests/Bannerlord.UIExtenderEx.Tests/Bannerlord.UIExtenderEx.Tests.csproj"
+test_results := root + "/artifacts/test-results"
+package_root := root + "/artifacts/package"
+module_output := package_root + "/bannerlord"
+nuget_output := package_root + "/nuget"
+module_id := "Bannerlord.UIExtenderEx"
+build_config := "Stable_Debug"
+package_config := "Stable_Release"
+configs := "Stable_Debug Stable_Release Beta_Debug Beta_Release"
+
+# Check required local tools and Bannerlord path configuration.
+doctor:
+    @command -v "{{ dotnet }}" >/dev/null 2>&1 || [[ -x "{{ dotnet }}" ]] || { echo "dotnet not found. Install the .NET SDK or set DOTNET=/path/to/dotnet."; exit 1; }
+    @"{{ dotnet }}" --version
+    @if command -v mono >/dev/null 2>&1; then mono --version | head -1; else echo "mono not found. Install mono to run net472 tests on Linux."; fi
+    @if command -v zip >/dev/null 2>&1; then zip -v | head -1; else echo "zip not found. Install zip to run 'just package' on Unix."; fi
+    @echo "BANNERLORD_GAME_DIR=${BANNERLORD_GAME_DIR:-<auto-resolve or unset>}"
+    @echo "BANNERLORD_STABLE_DIR=${BANNERLORD_STABLE_DIR:-<auto-resolve or unset>}"
+    @echo "BANNERLORD_BETA_DIR=${BANNERLORD_BETA_DIR:-<auto-resolve or unset>}"
+
+# Build the solution. Defaults to Stable_Debug.
+build configuration=build_config:
+    @"{{ dotnet }}" build "{{ solution }}" --configuration "{{ configuration }}" -p:Platform="{{ platform }}"
+
+# Build all supported configurations.
+build-all:
+    @for configuration in {{ configs }}; do "{{ dotnet }}" build "{{ solution }}" --configuration "$configuration" -p:Platform="{{ platform }}"; done
+
+# Run the NUnit test project. Defaults to Stable_Debug.
+test configuration=build_config:
+    @mkdir -p "{{ test_results }}"
+    @"{{ dotnet }}" test "{{ test_project }}" --configuration "{{ configuration }}" -p:Platform="{{ platform }}" --logger "trx;LogFileName={{ configuration }}.trx" --results-directory "{{ test_results }}"
+
+# Run tests for all supported configurations.
+test-all:
+    @mkdir -p "{{ test_results }}"
+    @for configuration in {{ configs }}; do "{{ dotnet }}" test "{{ test_project }}" --configuration "$configuration" -p:Platform="{{ platform }}" --logger "trx;LogFileName=$configuration.trx" --results-directory "{{ test_results }}"; done
+
+# Build a local module zip and NuGet packages. Defaults to Stable_Release.
+package configuration=package_config:
+    @command -v zip >/dev/null 2>&1 || { echo "zip not found. Install zip to run 'just package' on Unix."; exit 1; }
+    @rm -rf "{{ module_output }}" "{{ nuget_output }}"
+    @mkdir -p "{{ module_output }}" "{{ nuget_output }}"
+    @"{{ dotnet }}" build "{{ project }}" --configuration "{{ configuration }}" -p:Platform="{{ platform }}" -p:GameFolder="{{ module_output }}"
+    @"{{ dotnet }}" pack "{{ project }}" --configuration "{{ configuration }}" --no-build -p:Platform="{{ platform }}" --output "{{ nuget_output }}"
+    @test -d "{{ module_output }}/Modules/{{ module_id }}" || { echo "Expected module output not found: {{ module_output }}/Modules/{{ module_id }}"; exit 1; }
+    @cd "{{ module_output }}/Modules" && rm -f "{{ package_root }}/{{ module_id }}-{{ configuration }}.zip" && zip -qr "{{ package_root }}/{{ module_id }}-{{ configuration }}.zip" "{{ module_id }}"
+    @echo "Module zip: {{ package_root }}/{{ module_id }}-{{ configuration }}.zip"
+    @echo "NuGet packages: {{ nuget_output }}"
+
+# Build, test, then package using platform-specific recipes.
+all: build-all test-all package
+
+# Remove local artifacts and clean the solution. Defaults to Stable_Debug.
+clean configuration=build_config:
+    @rm -rf artifacts
+    @"{{ dotnet }}" clean "{{ solution }}" --configuration "{{ configuration }}" -p:Platform="{{ platform }}"

--- a/Justfile.windows
+++ b/Justfile.windows
@@ -1,0 +1,62 @@
+set dotenv-load := true
+set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command"]
+
+root := justfile_directory()
+dotnet := env_var_or_default("DOTNET", "dotnet")
+platform := env_var_or_default("PLATFORM", "x64")
+solution := root + "/src/Bannerlord.UIExtenderEx.sln"
+project := root + "/src/Bannerlord.UIExtenderEx/Bannerlord.UIExtenderEx.csproj"
+test_project := root + "/tests/Bannerlord.UIExtenderEx.Tests/Bannerlord.UIExtenderEx.Tests.csproj"
+test_results := root + "/artifacts/test-results"
+package_root := root + "/artifacts/package"
+module_output := package_root + "/bannerlord"
+nuget_output := package_root + "/nuget"
+module_id := "Bannerlord.UIExtenderEx"
+build_config := "Stable_Debug"
+package_config := "Stable_Release"
+
+# Check required local tools and Bannerlord path configuration.
+doctor:
+    & "{{ dotnet }}" --version; if ($LASTEXITCODE -ne 0) { Write-Error "dotnet not found. Install the .NET SDK or set DOTNET to dotnet.exe."; exit $LASTEXITCODE }
+    if (Get-Command Compress-Archive -ErrorAction SilentlyContinue) { Write-Host "Compress-Archive: available" } else { Write-Error "Compress-Archive is required for 'just package'."; exit 1 }
+    Write-Host "BANNERLORD_GAME_DIR=$($env:BANNERLORD_GAME_DIR)"
+    Write-Host "BANNERLORD_STABLE_DIR=$($env:BANNERLORD_STABLE_DIR)"
+    Write-Host "BANNERLORD_BETA_DIR=$($env:BANNERLORD_BETA_DIR)"
+
+# Build the solution. Defaults to Stable_Debug.
+build configuration=build_config:
+    & "{{ dotnet }}" build "{{ solution }}" --configuration "{{ configuration }}" -p:Platform="{{ platform }}"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+# Build all supported configurations.
+build-all:
+    foreach ($configuration in @("Stable_Debug", "Stable_Release", "Beta_Debug", "Beta_Release")) { & "{{ dotnet }}" build "{{ solution }}" --configuration $configuration -p:Platform="{{ platform }}"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE } }
+
+# Run the NUnit test project. Defaults to Stable_Debug.
+test configuration=build_config:
+    New-Item -ItemType Directory -Force "{{ test_results }}" | Out-Null
+    & "{{ dotnet }}" test "{{ test_project }}" --configuration "{{ configuration }}" -p:Platform="{{ platform }}" --logger "trx;LogFileName={{ configuration }}.trx" --results-directory "{{ test_results }}"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+# Run tests for all supported configurations.
+test-all:
+    New-Item -ItemType Directory -Force "{{ test_results }}" | Out-Null
+    foreach ($configuration in @("Stable_Debug", "Stable_Release", "Beta_Debug", "Beta_Release")) { & "{{ dotnet }}" test "{{ test_project }}" --configuration $configuration -p:Platform="{{ platform }}" --logger "trx;LogFileName=$configuration.trx" --results-directory "{{ test_results }}"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE } }
+
+# Build a local module zip and NuGet packages. Defaults to Stable_Release.
+package configuration=package_config:
+    if (Test-Path "{{ module_output }}") { Remove-Item -Recurse -Force "{{ module_output }}" }
+    if (Test-Path "{{ nuget_output }}") { Remove-Item -Recurse -Force "{{ nuget_output }}" }
+    New-Item -ItemType Directory -Force "{{ module_output }}", "{{ nuget_output }}" | Out-Null
+    & "{{ dotnet }}" build "{{ project }}" --configuration "{{ configuration }}" -p:Platform="{{ platform }}" -p:GameFolder="{{ module_output }}"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    & "{{ dotnet }}" pack "{{ project }}" --configuration "{{ configuration }}" --no-build -p:Platform="{{ platform }}" --output "{{ nuget_output }}"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    $modulePath = "{{ module_output }}/Modules/{{ module_id }}"; if (!(Test-Path $modulePath)) { Write-Error "Expected module output not found: $modulePath"; exit 1 }
+    $zipPath = "{{ package_root }}/{{ module_id }}-{{ configuration }}.zip"; if (Test-Path $zipPath) { Remove-Item -Force $zipPath }; Compress-Archive -Path $modulePath -DestinationPath $zipPath -Force
+    Write-Host "Module zip: {{ package_root }}/{{ module_id }}-{{ configuration }}.zip"
+    Write-Host "NuGet packages: {{ nuget_output }}"
+
+# Build, test, then package using platform-specific recipes.
+all: build-all test-all package
+
+# Remove local artifacts and clean the solution. Defaults to Stable_Debug.
+clean configuration=build_config:
+    if (Test-Path artifacts) { Remove-Item -Recurse -Force artifacts }
+    & "{{ dotnet }}" clean "{{ solution }}" --configuration "{{ configuration }}" -p:Platform="{{ platform }}"; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/README.md
+++ b/README.md
@@ -77,6 +77,39 @@ This mod is a dependency mod that does not provide anything by itself. You need 
 ## Usage
 Check the [``Articles``](https://butr.github.io/Bannerlord.UIExtenderEx/articles/v2/Overview.html) section of our documentation!
 
+## Development
+This repository includes a cross-platform `just` entrypoint. The root `Justfile` dispatches to `Justfile.unix` or `Justfile.windows` based on the host OS.
+
+Required tools:
+* [.NET SDK](https://dotnet.microsoft.com/download) available as `dotnet`, or set `DOTNET` to the full executable path.
+* `just` available on `PATH`.
+* Linux/WSL: `mono` is required for the `net472` test project, and `zip` is required for `just package`.
+* Windows: PowerShell with `Compress-Archive` is required for `just package`.
+
+Bannerlord path configuration is read by MSBuild from environment variables. Set one or more of these if auto-detection is not enough:
+* `BANNERLORD_GAME_DIR` for a single local Bannerlord install.
+* `BANNERLORD_STABLE_DIR` for `Stable_Debug` and `Stable_Release`.
+* `BANNERLORD_BETA_DIR` for `Beta_Debug` and `Beta_Release`.
+
+Examples:
+```bash
+DOTNET=/home/user/.dotnet/dotnet \
+BANNERLORD_GAME_DIR="/mnt/f/SteamLibrary/steamapps/common/Mount & Blade II Bannerlord" \
+just build Stable_Debug
+
+just test Stable_Debug
+just package Stable_Release
+```
+
+```powershell
+$env:BANNERLORD_GAME_DIR = "C:\Program Files (x86)\Steam\steamapps\common\Mount & Blade II Bannerlord"
+just build Stable_Debug
+just test Stable_Debug
+just package Stable_Release
+```
+
+Packaging writes local artifacts under `artifacts/package`: a Bannerlord module zip and NuGet packages.
+
 ## Current State of AutoGens
 The game uses two Prefab systems - static (pre-compiled XML) C# prefabs and dynamically serialized XML prefabs.  
 The XML prefabs were introduced with the Early Access.  

--- a/build/common.props
+++ b/build/common.props
@@ -6,7 +6,8 @@
     <!--Module Version-->
     <Version>2.13.3</Version>
     <!--Harmony Version-->
-    <HarmonyVersion>2.2.2</HarmonyVersion>
+    <HarmonyVersion>2.4.2.225</HarmonyVersion>
+    <HarmonyPackageVersion>2.4.2</HarmonyPackageVersion>
     <HarmonyExtensionsVersion>3.2.0.77</HarmonyExtensionsVersion>
     <HarmonyAnalyzerVersion>1.0.1.50</HarmonyAnalyzerVersion>
     <BuildResourcesVersion>1.1.0.129</BuildResourcesVersion>
@@ -14,24 +15,24 @@
     <BUTRModuleManagerVersion>6.0.247</BUTRModuleManagerVersion>
     <MCMVersion>5.5.3</MCMVersion>
     <!--Current Bannerlord Version-->
-    <GameVersion>1.0.0</GameVersion>
+    <GameVersion>1.3.15</GameVersion>
     <GameVersionWithPrefix>v$(GameVersion)</GameVersionWithPrefix>
     <!--Bannerlord's Root Folder. Leave empty if you want it to be tried to be autoresolved.-->
-    <GameFolder Condition="$(Configuration) == 'Stable_Debug' OR $(Configuration) == 'Stable_Release'">$(BANNERLORD_STABLE_DIR)</GameFolder>
-    <GameFolder Condition="$(Configuration) == 'Beta_Debug' OR $(Configuration) == 'Beta_Release'">$(BANNERLORD_BETA_DIR)</GameFolder>
-    <GameFolder Condition="$(BANNERLORD_STABLE_DIR) == '' AND $(BANNERLORD_BETA_DIR) == ''">$(BANNERLORD_GAME_DIR)</GameFolder>
+    <GameFolder Condition="'$(Configuration)' == 'Stable_Debug' OR '$(Configuration)' == 'Stable_Release'">$(BANNERLORD_STABLE_DIR)</GameFolder>
+    <GameFolder Condition="'$(Configuration)' == 'Beta_Debug' OR '$(Configuration)' == 'Beta_Release'">$(BANNERLORD_BETA_DIR)</GameFolder>
+    <GameFolder Condition="'$(BANNERLORD_STABLE_DIR)' == '' AND '$(BANNERLORD_BETA_DIR)' == ''">$(BANNERLORD_GAME_DIR)</GameFolder>
   </PropertyGroup>
 
   <!--Automatic Path Resolution-->
   <PropertyGroup>
     <!--Windows-->
     <!--Get from Registry (not working with dotnet right now)-->
-    <GameFolder Condition="!Exists($(GameFolder)) AND $(OS) == 'Windows_NT'">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 261550@InstallLocation)</GameFolder>
+    <GameFolder Condition="!Exists('$(GameFolder)') AND '$(OS)' == 'Windows_NT'">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 261550@InstallLocation)</GameFolder>
     <!--Set a default value if registry value is missing-->
-    <GameFolder Condition="!Exists($(GameFolder)) AND $(OS) == 'Windows_NT'">C:\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord</GameFolder>
+    <GameFolder Condition="!Exists('$(GameFolder)') AND '$(OS)' == 'Windows_NT'">C:\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord</GameFolder>
     <!--Unix-->
     <!--Set a default value if registry value is missing-->
-    <GameFolder Condition="!Exists($(GameFolder)) AND $(OS) == 'Unix'">~/.steam/root/steamapps/common/Mount &amp; Blade II Bannerlord</GameFolder>
+    <GameFolder Condition="!Exists('$(GameFolder)') AND '$(OS)' == 'Unix'">~/.steam/root/steamapps/common/Mount &amp; Blade II Bannerlord</GameFolder>
   </PropertyGroup>
 
 

--- a/src/Bannerlord.UIExtenderEx/Bannerlord.UIExtenderEx.csproj
+++ b/src/Bannerlord.UIExtenderEx/Bannerlord.UIExtenderEx.csproj
@@ -1,4 +1,4 @@
-﻿<!--EXTERNAL_PROPERTIES: GameVersion;HarmonyVersion;BuildResourcesVersion-->
+﻿<!--EXTERNAL_PROPERTIES: GameVersion;HarmonyVersion;HarmonyPackageVersion;BuildResourcesVersion-->
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -37,8 +37,7 @@
   <!--NuGet Package-->
 
   <ItemGroup>
-    <!-- Keep Bannerlord.Lib.Harmony intil we upgrade to v2.3.3 or higher -->
-    <PackageReference Include="Bannerlord.Lib.Harmony" Version="$(HarmonyVersion)" PrivateAssets="all" IncludeAssets="compile" />
+    <PackageReference Include="Lib.Harmony" Version="$(HarmonyPackageVersion)" PrivateAssets="all" IncludeAssets="compile" />
     <PackageReference Include="Bannerlord.ReferenceAssemblies.Core" Version="$(GameVersion).*" PrivateAssets="all" IncludeAssets="compile" GeneratePathProperty="true" />
     <PackageReference Include="BUTR.MessageBoxPInvoke" Version="1.0.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" PrivateAssets="all" />

--- a/src/Bannerlord.UIExtenderEx/ResourceManager/BrushFactoryManager.cs
+++ b/src/Bannerlord.UIExtenderEx/ResourceManager/BrushFactoryManager.cs
@@ -54,24 +54,24 @@ public static class BrushFactoryManager
             prefix: new HarmonyMethod(typeof(BrushFactoryManager), nameof(GetBrushPrefix)));
 
 #pragma warning disable BHA0001
+        var blankTranspiler = AccessTools2.DeclaredMethod(typeof(BrushFactoryManager), nameof(BlankTranspiler));
+
         // Preventing inlining GetBrush
-        harmony.TryPatch(
-            AccessTools2.DeclaredMethod("TaleWorlds.GauntletUI.PrefabSystem.ConstantDefinition:GetValue"),
-            transpiler: AccessTools2.DeclaredMethod(typeof(BrushFactoryManager), nameof(BlankTranspiler)));
-        harmony.TryPatch(
-            AccessTools2.DeclaredMethod("TaleWorlds.GauntletUI.PrefabSystem.WidgetExtensions:SetWidgetAttributeFromString"),
-            transpiler: AccessTools2.DeclaredMethod(typeof(BrushFactoryManager), nameof(BlankTranspiler)));
-        harmony.TryPatch(
-            AccessTools2.DeclaredMethod("TaleWorlds.GauntletUI.UIContext:GetBrush"),
-            transpiler: AccessTools2.DeclaredMethod(typeof(BrushFactoryManager), nameof(BlankTranspiler)));
-        harmony.TryPatch(
-            AccessTools2.DeclaredMethod("TaleWorlds.GauntletUI.PrefabSystem.WidgetExtensions:ConvertObject"),
-            transpiler: AccessTools2.DeclaredMethod(typeof(BrushFactoryManager), nameof(BlankTranspiler)));
-        harmony.TryPatch(
-            AccessTools2.DeclaredMethod("TaleWorlds.MountAndBlade.GauntletUI.Widgets.BoolBrushChangerBrushWidget:OnBooleanUpdated"),
-            transpiler: AccessTools2.DeclaredMethod(typeof(BrushFactoryManager), nameof(BlankTranspiler)));
+        TryPatchIfFound(harmony, "TaleWorlds.GauntletUI.PrefabSystem.ConstantDefinition:GetValue", blankTranspiler);
+        TryPatchIfFound(harmony, "TaleWorlds.GauntletUI.PrefabSystem.WidgetExtensions:SetWidgetAttributeFromString", blankTranspiler);
+        TryPatchIfFound(harmony, "TaleWorlds.GauntletUI.UIContext:GetBrush", blankTranspiler);
+        TryPatchIfFound(harmony, "TaleWorlds.GauntletUI.PrefabSystem.WidgetExtensions:ConvertObject", blankTranspiler);
+        TryPatchIfFound(harmony, "TaleWorlds.MountAndBlade.GauntletUI.Widgets.BoolBrushChangerBrushWidget:OnBooleanUpdated", blankTranspiler);
         // Preventing inlining GetBrush
 #pragma warning restore BHA0001
+    }
+
+    private static void TryPatchIfFound(Harmony harmony, string typeColonName, System.Reflection.MethodInfo? transpiler)
+    {
+        if (transpiler is not null && AccessTools2.DeclaredMethod(typeColonName, null, null, false) is { } method)
+        {
+            harmony.TryPatch(method, transpiler: transpiler);
+        }
     }
 
     [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "For ReSharper")]

--- a/src/Bannerlord.UIExtenderEx/ResourceManager/WidgetFactoryManager.cs
+++ b/src/Bannerlord.UIExtenderEx/ResourceManager/WidgetFactoryManager.cs
@@ -1,4 +1,5 @@
 ﻿using Bannerlord.UIExtenderEx.Patches;
+using Bannerlord.UIExtenderEx.Utils;
 
 using HarmonyLib;
 using HarmonyLib.BUTR.Extensions;
@@ -23,7 +24,18 @@ public static class WidgetFactoryManager
 {
     private delegate void ReloadDelegate();
     private static readonly ReloadDelegate? Reload =
-        AccessTools2.GetDeclaredDelegate<ReloadDelegate>(typeof(WidgetInfo), "Reload");
+        CreateWidgetInfoReloadDelegate();
+
+    private static ReloadDelegate? CreateWidgetInfoReloadDelegate()
+    {
+#pragma warning disable BHA0001
+        var method =
+            AccessTools2.DeclaredMethod(typeof(WidgetInfo), "Refresh", logErrorInTrace: false) ??
+            AccessTools2.DeclaredMethod(typeof(WidgetInfo), "Reload", logErrorInTrace: false);
+#pragma warning restore BHA0001
+
+        return method is null ? null : AccessTools2.GetDelegate<ReloadDelegate>(method);
+    }
 
     private static readonly AccessTools.FieldRef<WidgetFactory, IDictionary>? _liveCustomTypes =
         AccessTools2.FieldRefAccess<WidgetFactory, IDictionary>("_liveCustomTypes");
@@ -54,7 +66,11 @@ public static class WidgetFactoryManager
 
     public static void Register(Type widgetType)
     {
-        if (Reload is null) return;
+        if (Reload is null)
+        {
+            MessageUtils.DisplayUserWarning("WidgetInfo.Refresh/Reload was not found; custom widget type {0} could not be registered.", widgetType.FullName ?? widgetType.Name);
+            return;
+        }
 
         BuiltinTypes[widgetType.Name] = widgetType;
         Reload();
@@ -81,6 +97,8 @@ public static class WidgetFactoryManager
             prefix: new HarmonyMethod(typeof(WidgetFactoryManager), nameof(IsCustomTypePrefix)));
 
 #pragma warning disable BHA0001
+    var blankTranspiler = AccessTools2.DeclaredMethod(typeof(WidgetFactoryManager), nameof(BlankTranspiler));
+
         harmony.TryPatch(
             AccessTools2.DeclaredMethod(typeof(WidgetFactory), "OnUnload"),
             prefix: AccessTools2.DeclaredMethod(typeof(WidgetFactoryManager), nameof(OnUnloadPrefix)));
@@ -89,17 +107,19 @@ public static class WidgetFactoryManager
         // CreateBuiltinWidget is too complex to be inlined
         // GetWidgetTypes is not used?
         // Preventing inlining IsCustomType
-        harmony.TryPatch(
-            AccessTools2.DeclaredMethod("TaleWorlds.GauntletUI.PrefabSystem.WidgetTemplate:CreateWidgets"),
-            transpiler: AccessTools2.DeclaredMethod(typeof(WidgetFactoryManager), nameof(BlankTranspiler)));
-        harmony.TryPatch(
-            AccessTools2.DeclaredMethod("TaleWorlds.GauntletUI.PrefabSystem.WidgetTemplate:OnRelease"),
-            transpiler: AccessTools2.DeclaredMethod(typeof(WidgetFactoryManager), nameof(BlankTranspiler)));
+        TryPatchIfFound(harmony, "TaleWorlds.GauntletUI.PrefabSystem.WidgetTemplate:CreateWidgets", blankTranspiler);
+        TryPatchIfFound(harmony, "TaleWorlds.GauntletUI.PrefabSystem.WidgetTemplate:OnRelease", blankTranspiler);
         // Preventing inlining GetCustomType
-        harmony.TryPatch(
-            AccessTools2.DeclaredMethod("TaleWorlds.GauntletUI.Data.GauntletMovie:LoadMovie"),
-            transpiler: AccessTools2.DeclaredMethod(typeof(WidgetFactoryManager), nameof(BlankTranspiler)));
+        TryPatchIfFound(harmony, "TaleWorlds.GauntletUI.Data.GauntletMovie:LoadMovie", blankTranspiler);
 #pragma warning restore BHA0001
+    }
+
+    private static void TryPatchIfFound(Harmony harmony, string typeColonName, System.Reflection.MethodInfo? transpiler)
+    {
+        if (transpiler is not null && AccessTools2.DeclaredMethod(typeColonName, null, null, false) is { } method)
+        {
+            harmony.TryPatch(method, transpiler: transpiler);
+        }
     }
 
     [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "For ReSharper")]

--- a/src/Bannerlord.UIExtenderEx/ViewModels/BaseViewModelMixin.cs
+++ b/src/Bannerlord.UIExtenderEx/ViewModels/BaseViewModelMixin.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 using TaleWorlds.GauntletUI;
@@ -25,7 +26,9 @@ public abstract class BaseViewModelMixin<TViewModel> : IViewModelMixin where TVi
 {
     private delegate void OnPropertyChangedWithValueDelegate0(ViewModel instance, object value, [CallerMemberName] string? propertyName = null);
     private static readonly OnPropertyChangedWithValueDelegate0? OnPropertyChangedWithValue0 =
-        AccessTools2.GetDelegate<OnPropertyChangedWithValueDelegate0>(typeof(ViewModel), nameof(OnPropertyChangedWithValue));
+        typeof(ViewModel).GetMethod(nameof(OnPropertyChangedWithValue), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly, null, [typeof(object), typeof(string)], null) is { } method
+            ? AccessTools2.GetDelegate<OnPropertyChangedWithValueDelegate0>(method)
+            : null;
 
     private static readonly ConcurrentDictionary<Type, OnPropertyChangedWithValueDelegate0?> OnPropertyChangedWithValue1 = new();
 
@@ -97,9 +100,12 @@ public abstract class BaseViewModelMixin<TViewModel> : IViewModelMixin where TVi
             case Vec2 val when OnPropertyChangedWithValue8 is not null: OnPropertyChangedWithValue8(ViewModel, val, propertyName); return;
         }
 
-        static OnPropertyChangedWithValueDelegate0 ValueFactory(Type x) => AccessTools2.GetDelegate<OnPropertyChangedWithValueDelegate0>(AccessTools.GetDeclaredMethods(typeof(ViewModel))
-            .FirstOrDefault(x => x.IsGenericMethod && x.Name == nameof(OnPropertyChangedWithValue))?
-            .MakeGenericMethod(x));
+        static OnPropertyChangedWithValueDelegate0? ValueFactory(Type type)
+        {
+            var method = AccessTools.GetDeclaredMethods(typeof(ViewModel))
+                .FirstOrDefault(candidate => candidate.IsGenericMethod && candidate.Name == nameof(OnPropertyChangedWithValue));
+            return method is null ? null : AccessTools2.GetDelegate<OnPropertyChangedWithValueDelegate0>(method.MakeGenericMethod(type));
+        }
         if (OnPropertyChangedWithValue1.GetOrAdd(value.GetType(), ValueFactory) is { } del)
         {
             del(ViewModel, value, propertyName);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
 
-  <Import Project="../build/common.props" />
   <Import Project="../build/*.props" />
 
 </Project>

--- a/tests/Bannerlord.UIExtenderEx.Tests/Bannerlord.UIExtenderEx.Tests.csproj
+++ b/tests/Bannerlord.UIExtenderEx.Tests/Bannerlord.UIExtenderEx.Tests.csproj
@@ -1,4 +1,4 @@
-<!--EXTERNAL_PROPERTIES: GameFolder;GameVersion-->
+<!--EXTERNAL_PROPERTIES: GameFolder;GameVersion;HarmonyPackageVersion-->
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 
-    <PackageReference Include="Lib.Harmony" Version="$(HarmonyVersion)" />
+    <PackageReference Include="Lib.Harmony" Version="$(HarmonyPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>

--- a/tests/Bannerlord.UIExtenderEx.Tests/BaseTests.cs
+++ b/tests/Bannerlord.UIExtenderEx.Tests/BaseTests.cs
@@ -5,8 +5,10 @@ using HarmonyLib.BUTR.Extensions;
 
 using NUnit.Framework;
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Xml;
 
@@ -20,6 +22,32 @@ public class BaseTests : SharedTests
 {
     protected class MockWidgetFactory : WidgetFactory
     {
+        private const string PrefabXml = @"
+<Prefab>
+  <Window>
+    <OptionsScreenWidget Id=""Options"">
+      <Children>
+        <Standard.TopPanel Parameter.Title=""@OptionsLbl"">
+          <Children>
+            <ListPanel>
+              <Children>
+                <OptionsTabToggle Id=""InsertAsSibling""/>
+                <OptionsTabToggle Id=""InsertAsSibling""/>
+                <OptionsTabToggle Id=""ReplaceKeepChildren""/>
+                <OptionsTabToggle Id=""SetAttribute""/>
+                <OptionsTabToggle/>
+                <OptionsTabToggle/>
+              </Children>
+            </ListPanel>
+          </Children>
+        </Standard.TopPanel>
+      </Children>
+    </OptionsScreenWidget>
+  </Window>
+</Prefab>
+";
+      private static readonly object PrefabFileLock = new();
+
         private static readonly AccessTools.FieldRef<object, IDictionary>? GetCustomTypes =
             AccessTools2.FieldRefAccess<IDictionary>("TaleWorlds.GauntletUI.PrefabSystem.WidgetFactory:_customTypes");
 
@@ -54,37 +82,27 @@ public class BaseTests : SharedTests
 
         public static bool CreatePrefix(ref XmlReader __result)
         {
-            __result = XmlReader.Create(new StringReader(@"
-<Prefab>
-  <Window>
-    <OptionsScreenWidget Id=""Options"">
-      <Children>
-        <Standard.TopPanel Parameter.Title=""@OptionsLbl"">
-          <Children>
-            <ListPanel>
-              <Children>
-                <OptionsTabToggle Id=""InsertAsSibling""/>
-                <OptionsTabToggle Id=""InsertAsSibling""/>
-                <OptionsTabToggle Id=""ReplaceKeepChildren""/>
-                <OptionsTabToggle Id=""SetAttribute""/>
-                <OptionsTabToggle/>
-                <OptionsTabToggle/>
-              </Children>
-            </ListPanel>
-          </Children>
-        </Standard.TopPanel>
-      </Children>
-    </OptionsScreenWidget>
-  </Window>
-</Prefab>
-"), new XmlReaderSettings { IgnoreComments = true });
+            __result = XmlReader.Create(new StringReader(PrefabXml), new XmlReaderSettings { IgnoreComments = true });
             return false;
         }
 
         public static bool GetCustomTypePrefix(string typeName, ref WidgetPrefab __result)
         {
-            __result = WidgetPrefab.LoadFrom(new PrefabExtensionContext(), new WidgetAttributeContext(), typeName);
+            __result = WidgetPrefab.LoadFrom(new PrefabExtensionContext(), new WidgetAttributeContext(), EnsurePrefabFile(typeName));
             return false;
+        }
+
+        private static string EnsurePrefabFile(string typeName)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, typeName);
+            lock (PrefabFileLock)
+            {
+                if (!File.Exists(path) || new FileInfo(path).Length == 0)
+                {
+                    File.WriteAllText(path, PrefabXml);
+                }
+            }
+            return path;
         }
 
         private static bool GetPrefabNamesAndPathsFromCurrentPathPrefix(ref Dictionary<string, string> __result)
@@ -111,8 +129,10 @@ public class BaseTests : SharedTests
         }
     }
 
+#pragma warning disable BHA0006
     protected AccessTools.FieldRef<WidgetTemplate, List<WidgetTemplate>> GetChildren { get; } =
         AccessTools.FieldRefAccess<WidgetTemplate, List<WidgetTemplate>>("_children")!;
+#pragma warning restore BHA0006
 
     [OneTimeSetUp]
     public void OneTimeSetup()

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
 
-  <Import Project="../build/common.props" />
   <Import Project="../build/*.props" />
 
 </Project>


### PR DESCRIPTION

This PR updates Bannerlord.UIExtenderEx to support Mount & Blade II: Bannerlord 1.3.15 and upgrades Harmony to 2.4.2.225. It also introduces cross-platform build/test/package automation and improves developer documentation.

# Key Changes

- **Bannerlord 1.3.15 Support:** Updated all relevant version properties and references for compatibility.
- **Harmony 2.4.2.225:** Upgraded both the NuGet package and module version, with clear property separation and documentation.
- **Cross-Platform Automation:** Added a modular Justfile (with .unix/.windows dispatch) for build, test, and package tasks on both Linux and Windows.
- **Developer Documentation:** Expanded README with setup, tool requirements, and usage instructions for all supported platforms.
- **Test Fixture Improvements:** Enhanced test setup for prefab files and validation.
- **Minor Compatibility Fixes:** Addressed small runtime and error-handling issues for 1.3.15.
- **Diff Cleanup:** Normalized line endings and removed all EOL/whitespace churn—only intentional changes remain in the diff.

# Validation

- All builds and tests pass on both Linux and Windows (Mono and .NET SDK 8.0.421).
- Packaging produces expected artifacts.
- Only 13 files changed; all changes are intentional and documented.
- No runtime validation performed (pending prerequisites).

# Notes

- The split between `HarmonyVersion` (module) and `HarmonyPackageVersion` (NuGet) is intentional and documented.
- No .gitattributes or .editorconfig EOL enforcement is present; EOL normalization was handled manually for this PR.
- Please review the new Justfile and README for developer workflow improvements.
